### PR TITLE
FEATURE: Allow user to select vault

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -154,6 +154,7 @@ func (m VaultSelectionModel) View() string {
 	return s
 }
 
+// TODO Refactor and move to vault.1password.go
 func getVaults() ([]Vault, error) {
 	cmd := exec.Command("op", "vault", "list", "--format", "json")
 	output, err := cmd.Output()
@@ -185,6 +186,7 @@ func initConfig() {
 	configFile := filepath.Join(buchhalterConfigDir, ".buchhalter.yaml")
 	buchhalterDir := filepath.Join(homeDir, "buchhalter")
 
+	// TODO We check the existing part of the configuration file here and below -> refctor to only once
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
 		err := utils.CreateDirectoryIfNotExists(buchhalterConfigDir)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,7 +116,7 @@ func init() {
 	}
 }
 
-func (m VaultSelectionModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *VaultSelectionModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -142,13 +142,14 @@ func (m VaultSelectionModel) View() string {
 		return "\033[H\033[2J"
 	}
 
-	s := "Select the 1password vault that should be used with buchhalter:\n\n"
+	s := "Select the 1password vault that should be used with buchhalter cli:\n\n"
 	for i, vault := range m.vaults {
-		cursor := " "
 		if m.cursor == i {
-			cursor = ">"
+			s += "(•) "
+		} else {
+			s += "( ) "
 		}
-		s += fmt.Sprintf("%s %s\n", cursor, vault.Name)
+		s += vault.Name + "\n"
 	}
 	return s
 }
@@ -171,8 +172,8 @@ func getVaults() ([]Vault, error) {
 
 func selectVault(vaults []Vault) (Vault, error) {
 	model := VaultSelectionModel{vaults: vaults}
-	p := tea.NewProgram(model)
-	if err := p.Start(); err != nil {
+	p := tea.NewProgram(&model)
+	if _, err := p.Run(); err != nil {
 		return Vault{}, err
 	}
 	return model.vaults[model.choice], nil
@@ -193,7 +194,7 @@ func initConfig() {
 
 		vaults, err := getVaults()
 		if err != nil {
-			fmt.Println("Error listing vaults:", err)
+			fmt.Println("Error listing vaults. Make sure 1password cli is installed and you are logged in with eval $(op signin)", err)
 			os.Exit(1)
 		}
 
@@ -214,7 +215,6 @@ func initConfig() {
 	// Set default values for viper config
 	// Documented settings
 	viper.SetDefault("credential_provider_cli_command", "")
-	viper.SetDefault("credential_provider_vault", "Base")
 	viper.SetDefault("credential_provider_item_tag", "buchhalter-ai")
 	viper.SetDefault("buchhalter_directory", buchhalterDir)
 	viper.SetDefault("buchhalter_config_directory", buchhalterConfigDir)


### PR DESCRIPTION
This change adds a vault selector to buchhalter cli. When no .buchhalter.yaml config file exists, the existing vaults from 1password cli are read and a vault chooser is rendered for the user. The user can choose the vault he wants to use with buchhalter cli and it is automatically stored in the newly created .buchhalter.yaml config file. In the future it would make sense to have a dedicated "buchhalter vault" subcommand, too - e.g. listing all vaults with "buchhalter vault list", "buchhalter vault reconnect", etc. But that's not part of this PR. We just want to improve the workflow for first time users here.