### PR TITLE
Quit Chrome instance gracefully, if an abort signal is sent

### DIFF
--- a/lib/browser/quit.go
+++ b/lib/browser/quit.go
@@ -1,0 +1,15 @@
+package browser
+
+import (
+	"context"
+
+	"github.com/chromedp/chromedp"
+)
+
+// Quit cancels a chromedp context, waits for its resources to be cleaned up,
+// and returns any error encountered during that process.
+//
+// ctx needs to be a chromedp.Context to work properly.
+func Quit(ctx context.Context) error {
+	return chromedp.Cancel(ctx)
+}


### PR DESCRIPTION
## Testing before this branch

1. Run `make build && bin/buchhalter sync --log --dev`
2. See the browser is launching
3. Go to your terminal and hit `q` (or `control + C`)
4. Your program quits
5. Press `cmd + tab`
6. You should see an open chrome instance that has been left by buchhalter

## Testing with this branch

Execute step 1. until 5.
6. You should see no open chrome instance

## Success case

Please also test the success case (receiving normal invoice downloads)

## Ticket

Fix #30

## Other Pull Request

This Pull Request is replacing https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/26