### PR TITLE
New cmd `buchhalter vault select`

### DIFF
--- a/cmd/vault-select.go
+++ b/cmd/vault-select.go
@@ -224,7 +224,7 @@ func (m ViewModelVaultSelect) View() string {
 		for i := 0; i < len(m.selectionChoices); i++ {
 			currentConfigValue := ""
 			if m.selectionChoices[i].Name == m.selectionChoice || m.selectionChoices[i].ID == m.selectionChoice {
-				currentConfigValue = textStyleBold(" (current configured)")
+				currentConfigValue = textStyleBold(" (currently configured)")
 			}
 			if m.selectionCursor == i {
 				s.WriteString("(•) ")

--- a/cmd/vault-select.go
+++ b/cmd/vault-select.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"buchhalter/lib/vault"
+)
+
+// selectCmd represents the `vault select` command
+var selectCmd = &cobra.Command{
+	Use:   "select",
+	Short: "Select the 1Password vault that should be used with buchhalter-cli",
+	Long: `Your secrets can be organized via vaults inside 1Password. buchhalter-cli is respecting these vaults to only retrieve items from a single vault. To know which vault should be used, the vault need to be selected.longer description that spans multiple lines and likely contains examples. For example:
+
+(•) Private
+( ) ACME Corp
+( ) Reddit Side Project
+
+The chosen Vault name will be stores inside a local configuration for later use.`,
+	Run: RunVaultSelectCommand,
+}
+
+func init() {
+	vaultCmd.AddCommand(selectCmd)
+}
+
+func RunVaultSelectCommand(cmd *cobra.Command, args []string) {
+	// Init logging
+	buchhalterDirectory := viper.GetString("buchhalter_directory")
+	developmentMode := viper.GetBool("dev")
+	logSetting, err := cmd.Flags().GetBool("log")
+	if err != nil {
+		exitMessage := fmt.Sprintf("Error reading log flag: %s", err)
+		exitWithLogo(exitMessage)
+	}
+	logger, err := initializeLogger(logSetting, developmentMode, buchhalterDirectory)
+	if err != nil {
+		exitMessage := fmt.Sprintf("Error on initializing logging: %s", err)
+		exitWithLogo(exitMessage)
+	}
+	logger.Info("Booting up", "development_mode", developmentMode)
+	defer logger.Info("Shutting down")
+
+	// Init UI
+	spinnerModel := spinner.New()
+	spinnerModel.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
+	viewModel := ViewModelVaultSelect{
+		showSelection:    false,
+		selectionChoice:  viper.GetString("credential_provider_vault"),
+		actionsCompleted: []string{},
+		actionInProgress: "Initializing connection to Password Vault",
+		spinner:          spinnerModel,
+	}
+
+	// Run the program
+	p := tea.NewProgram(&viewModel)
+	if _, err := p.Run(); err != nil {
+		logger.Error("Error running program", "error", err)
+		exitMessage := fmt.Sprintf("Error running program: %s", err)
+		exitWithLogo(exitMessage)
+	}
+}
+
+type ViewModelVaultSelect struct {
+	actionsCompleted []string
+	actionInProgress string
+	actionError      string
+	spinner          spinner.Model
+
+	// Vault selection
+	showSelection    bool
+	selectionCursor  int
+	selectionChoice  string
+	selectionChoices []vault.Vault
+}
+
+type vaultSelectErrorMsg struct {
+	err string
+}
+
+type vaultSelectInitSuccessMsg struct {
+	vaults []vault.Vault
+}
+
+func vaultSelectInitCmd() tea.Msg {
+	// Init vault provider
+	vaultConfigBinary := viper.GetString("credential_provider_cli_command")
+	vaultProvider, err := vault.GetProvider(vault.PROVIDER_1PASSWORD, vaultConfigBinary, "", "")
+	if err != nil {
+		return vaultSelectErrorMsg{err: vaultProvider.GetHumanReadableErrorMessage(err)}
+	}
+
+	// Get vaults
+	vaults, err := vaultProvider.GetVaults()
+	if err != nil {
+		return vaultSelectErrorMsg{err: vaultProvider.GetHumanReadableErrorMessage(err)}
+	}
+	return vaultSelectInitSuccessMsg{
+		vaults: vaults,
+	}
+}
+
+type writeConfigFileMsg struct {
+	vaultName string
+	err       error
+}
+
+func (m ViewModelVaultSelect) Init() tea.Cmd {
+	return tea.Batch(vaultSelectInitCmd, m.spinner.Tick)
+}
+
+func (m ViewModelVaultSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+
+		case "enter":
+			// We only allow enter if the vault selection is shown
+			if !m.showSelection {
+				return m, nil
+			}
+
+			// Deactivate selection
+			m.showSelection = false
+			m.actionInProgress = ""
+			m.actionsCompleted = append(m.actionsCompleted, "Selected the 1Password vault that should be used with buchhalter-cli")
+
+			// Send the choice on the channel and exit.
+			m.selectionChoice = m.selectionChoices[m.selectionCursor].ID
+			selectedVaultName := m.selectionChoices[m.selectionCursor].Name
+
+			return m, func() tea.Msg {
+				viper.Set("credential_provider_vault", m.selectionChoice)
+				configFile := viper.GetString("buchhalter_config_file")
+				err := viper.WriteConfigAs(configFile)
+				if err != nil {
+					return writeConfigFileMsg{
+						vaultName: selectedVaultName,
+						err:       err,
+					}
+				}
+				return writeConfigFileMsg{vaultName: selectedVaultName}
+			}
+
+		case "down", "j":
+			// We only allow enter if the vault selection is shown
+			if !m.showSelection {
+				return m, nil
+			}
+
+			m.selectionCursor++
+			if m.selectionCursor >= len(m.selectionChoices) {
+				m.selectionCursor = 0
+			}
+
+		case "up", "k":
+			// We only allow enter if the vault selection is shown
+			if !m.showSelection {
+				return m, nil
+			}
+
+			m.selectionCursor--
+			if m.selectionCursor < 0 {
+				m.selectionCursor = len(m.selectionChoices) - 1
+			}
+		}
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case vaultSelectErrorMsg:
+		m.actionError = msg.err
+		return m, tea.Quit
+
+	case vaultSelectInitSuccessMsg:
+		m.selectionChoices = msg.vaults
+		m.actionInProgress = ""
+		m.actionsCompleted = append(m.actionsCompleted, "Initializing connection to Password Vault")
+
+		// Show Vault selection
+		m.actionInProgress = "Select the 1Password vault that should be used with buchhalter-cli"
+		m.showSelection = true
+
+	case writeConfigFileMsg:
+		if msg.err != nil {
+			m.actionError = fmt.Sprintf("Error creating config file: %s", msg.err)
+			return m, tea.Quit
+		}
+
+		m.actionsCompleted = append(m.actionsCompleted, fmt.Sprintf("Configured 1Password vault '%s' as new default", msg.vaultName))
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+func (m ViewModelVaultSelect) View() string {
+	s := strings.Builder{}
+	s.WriteString(headerStyle(LogoText) + "\n\n")
+
+	for _, actionCompleted := range m.actionsCompleted {
+		s.WriteString(checkMark.Render() + " " + textStyleBold(actionCompleted) + "\n")
+	}
+
+	if len(m.actionInProgress) > 0 {
+		s.WriteString(m.spinner.View() + " " + textStyleBold(m.actionInProgress) + "\n")
+	}
+
+	if len(m.actionError) > 0 {
+		s.WriteString(errorkMark.Render() + " " + textStyleBold(m.actionError) + "\n")
+	}
+
+	if m.showSelection {
+		for i := 0; i < len(m.selectionChoices); i++ {
+			currentConfigValue := ""
+			if m.selectionChoices[i].Name == m.selectionChoice || m.selectionChoices[i].ID == m.selectionChoice {
+				currentConfigValue = textStyleBold(" (current configured)")
+			}
+			if m.selectionCursor == i {
+				s.WriteString("(•) ")
+			} else {
+				s.WriteString("( ) ")
+			}
+			s.WriteString(m.selectionChoices[i].Name)
+			s.WriteString(currentConfigValue)
+			s.WriteString("\n")
+		}
+	}
+
+	s.WriteString("\n(press q to quit)\n")
+
+	return s.String()
+}

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// vaultCmd represents the vault command
+var vaultCmd = &cobra.Command{
+	Use:   "vault",
+	Short: "Sub-Commands to manage the password vault",
+	Long:  `Sub-Commands to manage the password vault.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Nothing to see here. Try `buchhalter help vault`.")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(vaultCmd)
+}

--- a/lib/vault/types.go
+++ b/lib/vault/types.go
@@ -7,15 +7,17 @@ import (
 
 type Items []Item
 
+type Vault struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type Item struct {
-	ID      string   `json:"id"`
-	Title   string   `json:"title"`
-	Tags    []string `json:"tags"`
-	Version int      `json:"version"`
-	Vault   struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"vault"`
+	ID                    string    `json:"id"`
+	Title                 string    `json:"title"`
+	Tags                  []string  `json:"tags"`
+	Version               int       `json:"version"`
+	Vault                 Vault     `json:"vault"`
 	Category              string    `json:"category"`
 	LastEditedBy          string    `json:"last_edited_by"`
 	CreatedAt             time.Time `json:"created_at"`


### PR DESCRIPTION
This PR reverts parts of https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/100, as it has downsides of requiring 1Password connections, even if you only want to show the version.

We introduce a new command: `buchhalter vault select`

This commands provides a select of all your vaults in buchhalter.