### PR TITLE
`sync` cmd: Rework view/ui layer to show actions that are performed

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -722,57 +722,57 @@ func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View renders the bubbletea application view.
 // Renders the UI based on the data in the model.
 func (m viewModel) View() string {
-	var s string
-	s = fmt.Sprintf(
+	s := strings.Builder{}
+	s.WriteString(fmt.Sprintf(
 		"%s\n%s\n%s%s\n%s\n",
 		headerStyle(LogoText),
 		textStyle("Automatically sync all your incoming invoices from your suppliers. "),
 		textStyle("More information at: "),
 		textStyleBold("https://buchhalter.ai"),
 		textStyleGrayBold(fmt.Sprintf("Using OICDB %s and CLI %s", m.recipeParser.OicdbVersion, cliVersion)),
-	) + "\n"
+	) + "\n")
 
 	if !m.hasError {
-		s += m.spinner.View() + m.currentAction
-		s += helpStyle.Render("  " + m.details)
+		s.WriteString(m.spinner.View() + m.currentAction)
+		s.WriteString(helpStyle.Render("  " + m.details))
 	} else {
-		s += errorStyle.Render("ERROR: " + m.currentAction)
-		s += helpStyle.Render("  " + m.details)
+		s.WriteString(errorStyle.Render("ERROR: " + m.currentAction))
+		s.WriteString(helpStyle.Render("  " + m.details))
 	}
 
-	s += "\n"
+	s.WriteString("\n")
 
 	if m.showProgress {
-		s += m.progress.View() + "\n\n"
+		s.WriteString(m.progress.View() + "\n\n")
 	}
 
 	if !m.hasError && m.mode == "sync" {
 		for _, res := range m.results {
-			s += res.String() + "\n"
+			s.WriteString(res.String() + "\n")
 		}
 	}
 
 	if m.mode == "sendMetrics" && !m.quitting {
 		for i := 0; i < len(choices); i++ {
 			if m.cursor == i {
-				s += "(•) "
+				s.WriteString("(•) ")
 			} else {
-				s += "( ) "
+				s.WriteString("( ) ")
 			}
-			s += choices[i]
-			s += "\n"
+			s.WriteString(choices[i])
+			s.WriteString("\n")
 		}
 	}
 
 	// Quitting or not?
 	if !m.quitting {
-		s += helpStyle.Render("Press q to exit")
+		s.WriteString(helpStyle.Render("Press q to exit"))
 	}
 	if m.quitting {
-		s += "\n"
+		s.WriteString("\n")
 	}
 
-	return appStyle.Render(s)
+	return appStyle.Render(s.String())
 }
 
 func tickCmd() tea.Cmd {

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhA
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/lib/browser/browser.go
+++ b/lib/browser/browser.go
@@ -151,9 +151,9 @@ func (b *BrowserDriver) RunRecipe(p *tea.Program, totalStepCount int, stepCountI
 	n := 1
 	var result utils.RecipeResult
 	for _, step := range recipe.Steps {
-		p.Send(utils.ViewMsgStatusAndDescriptionUpdate{
-			Title:       fmt.Sprintf("Downloading invoices from %s (%d/%d):", recipe.Supplier, n, stepCountInCurrentRecipe),
-			Description: step.Description,
+		p.Send(utils.ViewStatusUpdateMsg{
+			Message: fmt.Sprintf("Downloading invoices from `%s` (%d/%d):", recipe.Supplier, n, stepCountInCurrentRecipe),
+			Details: step.Description,
 		})
 
 		stepResultChan := make(chan utils.StepResult, 1)
@@ -265,7 +265,7 @@ func (b *BrowserDriver) RunRecipe(p *tea.Program, totalStepCount int, stepCountI
 			}
 		}
 		cs = (float64(baseCountStep) + float64(n)) / float64(totalStepCount)
-		p.Send(utils.ViewMsgProgressUpdate{Percent: cs})
+		p.Send(utils.ViewProgressUpdateMsg{Percent: cs})
 		n++
 	}
 

--- a/lib/browser/oauth2.go
+++ b/lib/browser/oauth2.go
@@ -136,9 +136,9 @@ func (b *ClientAuthBrowserDriver) RunRecipe(p *tea.Program, totalStepCount int, 
 	n := 1
 	var result utils.RecipeResult
 	for _, step := range recipe.Steps {
-		p.Send(utils.ViewMsgStatusAndDescriptionUpdate{
-			Title:       fmt.Sprintf("Downloading invoices from %s (%d/%d):", recipe.Supplier, n, stepCountInCurrentRecipe),
-			Description: step.Description,
+		p.Send(utils.ViewStatusUpdateMsg{
+			Message: fmt.Sprintf("Downloading invoices from `%s` (%d/%d):", recipe.Supplier, n, stepCountInCurrentRecipe),
+			Details: step.Description,
 		})
 
 		stepResultChan := make(chan utils.StepResult, 1)
@@ -202,7 +202,7 @@ func (b *ClientAuthBrowserDriver) RunRecipe(p *tea.Program, totalStepCount int, 
 		}
 
 		cs = (float64(baseCountStep) + float64(n)) / float64(totalStepCount)
-		p.Send(utils.ViewMsgProgressUpdate{Percent: cs})
+		p.Send(utils.ViewProgressUpdateMsg{Percent: cs})
 		n++
 	}
 

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -20,16 +20,18 @@ const (
 	randomStringCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
-// ViewMsgProgressUpdate updates the progress bar in the bubbletea application.
+// ViewProgressUpdateMsg updates the progress bar in the bubbletea application.
 // "Percent" represents the percentage of the progress bar.
-type ViewMsgProgressUpdate struct {
+type ViewProgressUpdateMsg struct {
 	Percent float64
 }
 
-// ViewMsgStatusAndDescriptionUpdate updates the status and description in the bubbletea application.
-type ViewMsgStatusAndDescriptionUpdate struct {
-	Title       string
-	Description string
+type ViewStatusUpdateMsg struct {
+	Message    string
+	Details    string
+	Err        error
+	Completed  bool
+	ShouldQuit bool
 }
 
 // RecipeResult represents the result of a single recipe execution.


### PR DESCRIPTION
## Context

This PR is a bit bigger (code line-wise).
It is reworking the UI to 
* make it a bit simpler to understand (e.g., via fewer message types)
* list the operations in the UI

## Caveats

### **sendMetrics**

Right now, the `sendMetrics` command is shown with a spinner. When completed, it disappears and is _not_ shown in the list of performed operations.
This part needs rework anyway to remove it from the logic where we are running a browser.
This will be done in a future pull request.

## TODOs

A few things are still open - Those may be done in future pull requests (to avoid this is getting bigger)

* Rework `sendMetrics` command logic --> Fixed in https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/107
* Show progress bar only when we are ready to launch a browser (the client can fail before we even think about starting a browser)
* When an error appears, but the program can continue, list the error in the same way as a normal operation --> Fixed in https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/106