### PR TITLE
sync cmd: Move sendMetrics out of the event loop

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ var textStyleBold = lipgloss.NewStyle().Bold(true).Render
 var headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9FC131")).Render
 var checkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓")
 var errorkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).SetString("X")
+var thanksMark = lipgloss.NewStyle().SetString("🙏")
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -57,6 +57,7 @@ type UIActionStyle string
 const (
 	UIActionStyleSuccess UIActionStyle = "success"
 	UIActionStyleError   UIActionStyle = "error"
+	UIActionStyleThanks  UIActionStyle = "thanks"
 )
 
 type UIAction struct {


### PR DESCRIPTION
### What is this Pull Request doing?

* Add error reporting into `sendMetrics`
* Move the `sendMetrics` choices (`[]string{"Yes", "No", "Always yes (don't ask again)"}`) into the view model
* Moved `sendMetrics` out of the event loop into its own `tea.Cmd`

## Merge order

This PR is based on https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/106
https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/106 need to be merged before.
