### PR TITLE
`sync` cmd: Move init operations into command logic to start Bubbletea application earlier

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ var textStyleBold = lipgloss.NewStyle().Bold(true).Render
 var headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9FC131")).Render
 var checkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓")
 var errorkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).SetString("X")
+var thanksMark = lipgloss.NewStyle().SetString("🙏")
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -202,9 +202,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	})
 
 	p.Send(buchhalterMetricsRecord{
-		CliVersion: cliVersion,
-		// TODO Send ChromeVersion (not available in this scope)
-		// ChromeVersion: ChromeVersion,
+		CliVersion:   cliVersion,
 		VaultVersion: vaultProvider.Version,
 		OicdbVersion: recipeParser.OicdbVersion,
 	})
@@ -419,6 +417,11 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 			// In case of an external abort signal (e.g. CTRL+C), bubbletea will call `chromedp.Cancel()`.
 		}
 
+		// Send ChromeVersion into metrics
+		if len(ChromeVersion) > 0 {
+			p.Send(buchhalterMetricsRecord{ChromeVersion: ChromeVersion})
+		}
+
 		// TODO recipeResult can be empty! (not nil, but without values)
 
 		rdx := repository.RunDataSupplier{
@@ -605,8 +608,8 @@ func prepareRecipes(logger *slog.Logger, supplier string, vaultProvider *vault.P
 	return r, nil
 }
 
-func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, ChromeVersion, vaultVersion, oicdbVersion string) error {
-	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, ChromeVersion, vaultVersion, oicdbVersion)
+func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, chromeVersion, vaultVersion, oicdbVersion string) error {
+	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, chromeVersion, vaultVersion, oicdbVersion)
 	if err != nil {
 		return fmt.Errorf("error sending usage metrics to Buchhalter API: %w", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -667,9 +667,7 @@ type viewModelSync struct {
 	metricsRecord    *buchhalterMetricsRecord
 
 	// Buchhalter
-	vaultProvider       *vault.Provider1Password
 	buchhalterAPIClient *repository.BuchhalterAPIClient
-	recipeParser        *parser.RecipeParser
 	logger              *slog.Logger
 
 	// Browser

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -128,8 +128,8 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 	logger.Info("Credential items loaded from vault", "num_items", len(vaultItems), "provider", "1Password", "cli_command", vaultConfigBinary, "vault", vaultConfigBase, "tag", vaultConfigTag)
 
-	// Run recipes
-	go runRecipes(p, logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum, vaultProvider, documentArchive, recipeParser, buchhalterAPIClient)
+	// Run the primary logic
+	go runSyncCommandLogic(p, logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum, vaultProvider, documentArchive, recipeParser, buchhalterAPIClient)
 
 	if _, err := p.Run(); err != nil {
 		logger.Error("Error running program", "error", err)
@@ -138,7 +138,7 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 }
 
-func runRecipes(p *tea.Program, logger *slog.Logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum string, vaultProvider *vault.Provider1Password, documentArchive *archive.DocumentArchive, recipeParser *parser.RecipeParser, buchhalterAPIClient *repository.BuchhalterAPIClient) {
+func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum string, vaultProvider *vault.Provider1Password, documentArchive *archive.DocumentArchive, recipeParser *parser.RecipeParser, buchhalterAPIClient *repository.BuchhalterAPIClient) {
 	p.Send(utils.ViewStatusUpdateMsg{Message: "Building archive index"})
 	logger.Info("Building document archive index ...")
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -106,8 +106,8 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 
 	// Init the bubbletea program
-	viewModel := initialModel(logger, buchhalterAPIClient)
-	p := tea.NewProgram(viewModel)
+	viewModelSync := initviewModelSync(logger, buchhalterAPIClient)
+	p := tea.NewProgram(viewModelSync)
 
 	// Run the primary logic
 	go runSyncCommandLogic(p, logger, config, supplier, buchhalterAPIClient)
@@ -641,8 +641,8 @@ var (
 	appStyle      = lipgloss.NewStyle().Margin(1, 2, 0, 2)
 )
 
-// viewModel is the bubbletea application main viewModel (view)
-type viewModel struct {
+// viewModelSync is the bubbletea application main view model
+type viewModelSync struct {
 	mode string
 
 	// UI
@@ -718,15 +718,15 @@ type viewMsgModeUpdate struct {
 
 type tickMsg time.Time
 
-// initialModel returns the model for the bubbletea application.
-func initialModel(logger *slog.Logger, buchhalterAPIClient *repository.BuchhalterAPIClient) viewModel {
+// initviewModelSync returns the model for the bubbletea application.
+func initviewModelSync(logger *slog.Logger, buchhalterAPIClient *repository.BuchhalterAPIClient) viewModelSync {
 	const numLastResults = 5
 
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = spinnerStyle
 
-	m := viewModel{
+	m := viewModelSync{
 		actionsCompleted: []utils.UIAction{},
 
 		mode:         "sync",
@@ -752,13 +752,13 @@ func initialModel(logger *slog.Logger, buchhalterAPIClient *repository.Buchhalte
 
 // Init initializes the bubbletea application.
 // Returns an initial command for the application to run.
-func (m viewModel) Init() tea.Cmd {
+func (m viewModelSync) Init() tea.Cmd {
 	return m.spinner.Tick
 }
 
 // Update updates the bubbletea application model.
 // Handles incoming events and updates the model accordingly.
-func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m viewModelSync) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
 	case tea.KeyMsg:
@@ -930,7 +930,7 @@ func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the bubbletea application view.
 // Renders the UI based on the data in the model.
-func (m viewModel) View() string {
+func (m viewModelSync) View() string {
 	s := strings.Builder{}
 	s.WriteString(fmt.Sprintf(
 		"%s\n%s\n%s%s\n%s\n",
@@ -1016,7 +1016,7 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-func quit(m viewModel) viewModel {
+func quit(m viewModelSync) viewModelSync {
 	m.quitting = true
 	m.showProgress = false
 

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -57,6 +57,7 @@ type UIActionStyle string
 const (
 	UIActionStyleSuccess UIActionStyle = "success"
 	UIActionStyleError   UIActionStyle = "error"
+	UIActionStyleThanks  UIActionStyle = "thanks"
 )
 
 type UIAction struct {


### PR DESCRIPTION
The `sync` cmd initialized many objects and ran a few operations before the bubble tea application started.
This had the effect that the user received a 1Password prompt before any application output was done. UI/UX wise, this seems strange:
1. You start the app
2. No output
3. 1Passwort wants you to authenticate

After the change, the buchhalter logo is shown and a message is shown that you try to initialize the 1Passwort Vault provider.

Additionally, many more operations are shown in the UI as successful.

<img width="800" alt="Screenshot 2024-09-15 at 22 00 49" src="https://github.com/user-attachments/assets/00da03b9-a35e-46c5-91d1-acd063889e68">

## Merge order

This PR depends on https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/107
https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/107 need to be merged before.