### PR TITLE
`vault`: Let `GetHumanReadableErrorMessage` return a proper error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ var textStyleBold = lipgloss.NewStyle().Bold(true).Render
 var headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9FC131")).Render
 var checkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓")
 var errorkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).SetString("X")
+var thanksMark = lipgloss.NewStyle().SetString("🙏")
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -125,10 +125,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	p.Send(utils.ViewStatusUpdateMsg{Message: statusUpdateMessage})
 	vaultProvider, err := vault.GetProvider(vault.PROVIDER_1PASSWORD, config.vaultConfigBinary, config.vaultConfigBase, config.vaultConfigTag)
 	if err != nil {
-		logger.Error(vaultProvider.GetHumanReadableErrorMessage(err))
-		exitMessage := fmt.Sprintln(vaultProvider.GetHumanReadableErrorMessage(err))
+		logger.Error("error initializing credential provider 1Password: %s", "error", err)
 		p.Send(utils.ViewStatusUpdateMsg{
-			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", exitMessage),
+			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", vaultProvider.GetHumanReadableErrorMessage(err)),
 			Completed:  true,
 			ShouldQuit: true,
 		})
@@ -138,10 +137,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	// Load vault items/try to connect to vault
 	vaultItems, err := vaultProvider.LoadVaultItems()
 	if err != nil {
-		logger.Error(vaultProvider.GetHumanReadableErrorMessage(err))
-		exitMessage := fmt.Sprintln(vaultProvider.GetHumanReadableErrorMessage(err))
+		logger.Error("error initializing credential provider 1Password", "error", err)
 		p.Send(utils.ViewStatusUpdateMsg{
-			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", exitMessage),
+			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", vaultProvider.GetHumanReadableErrorMessage(err)),
 			Completed:  true,
 			ShouldQuit: true,
 		})
@@ -334,10 +332,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		logger.Info("Requesting credentials from vault", "supplier", recipesToExecute[i].recipe.Supplier)
 		recipeCredentials, err := vaultProvider.GetCredentialsByItemId(recipesToExecute[i].vaultItemId)
 		if err != nil {
-			logger.Error(vaultProvider.GetHumanReadableErrorMessage(err))
-			// TODO Let `GetHumanReadableErrorMessage` return a proper error
+			logger.Error("error while requesting credentials from vault", "supplier", recipesToExecute[i].recipe.Supplier, "error", err)
 			p.Send(utils.ViewStatusUpdateMsg{
-				Err:       errors.New(vaultProvider.GetHumanReadableErrorMessage(err)),
+				Err:       vaultProvider.GetHumanReadableErrorMessage(err),
 				Completed: true,
 			})
 			continue

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -199,12 +199,6 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		Completed: true,
 	})
 
-	p.Send(buchhalterMetricsRecord{
-		CliVersion:   cliVersion,
-		VaultVersion: vaultProvider.Version,
-		OicdbVersion: recipeParser.OicdbVersion,
-	})
-
 	p.Send(utils.ViewStatusUpdateMsg{Message: "Building archive index"})
 	logger.Info("Building document archive index ...")
 
@@ -280,6 +274,13 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		return
 	}
 
+	// At this point in time, we have all the information we need to send metrics
+	p.Send(buchhalterMetricsRecord{
+		CliVersion:   cliVersion,
+		VaultVersion: vaultProvider.Version,
+		OicdbVersion: recipeParser.OicdbVersion,
+	})
+
 	// No pair of credentials found for supplier/recipes
 	if len(recipesToExecute) == 0 {
 		loggingErrorMessage := "No recipes found for suppliers"
@@ -293,6 +294,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		})
 		return
 	}
+	statusUpdateMessage = fmt.Sprintf("%s (OICDB %s)", statusUpdateMessage, recipeParser.OicdbVersion)
 	p.Send(utils.ViewStatusUpdateMsg{
 		Message:   statusUpdateMessage,
 		Completed: true,
@@ -932,8 +934,6 @@ func (m viewModelSync) View() string {
 		textStyle("More information at: "),
 		textStyleBold("https://buchhalter.ai"),
 		textStyleGrayBold(fmt.Sprintf("Using CLI %s", cliVersion)),
-		// TODO Outputting OICDB as task
-		//textStyleGrayBold(fmt.Sprintf("Using OICDB %s and CLI %s", m.recipeParser.OicdbVersion, cliVersion)),
 	) + "\n")
 
 	for _, actionCompleted := range m.actionsCompleted {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -202,9 +202,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	})
 
 	p.Send(buchhalterMetricsRecord{
-		CliVersion: cliVersion,
-		// TODO Send ChromeVersion (not available in this scope)
-		// ChromeVersion: ChromeVersion,
+		CliVersion:   cliVersion,
 		VaultVersion: vaultProvider.Version,
 		OicdbVersion: recipeParser.OicdbVersion,
 	})
@@ -419,6 +417,11 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 			// In case of an external abort signal (e.g. CTRL+C), bubbletea will call `chromedp.Cancel()`.
 		}
 
+		// Send ChromeVersion into metrics
+		if len(ChromeVersion) > 0 {
+			p.Send(buchhalterMetricsRecord{ChromeVersion: ChromeVersion})
+		}
+
 		// TODO recipeResult can be empty! (not nil, but without values)
 
 		rdx := repository.RunDataSupplier{
@@ -605,8 +608,8 @@ func prepareRecipes(logger *slog.Logger, supplier string, vaultProvider *vault.P
 	return r, nil
 }
 
-func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, ChromeVersion, vaultVersion, oicdbVersion string) error {
-	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, ChromeVersion, vaultVersion, oicdbVersion)
+func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, chromeVersion, vaultVersion, oicdbVersion string) error {
+	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, chromeVersion, vaultVersion, oicdbVersion)
 	if err != nil {
 		return fmt.Errorf("error sending usage metrics to Buchhalter API: %w", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -667,9 +667,7 @@ type viewModelSync struct {
 	metricsRecord    *buchhalterMetricsRecord
 
 	// Buchhalter
-	vaultProvider       *vault.Provider1Password
 	buchhalterAPIClient *repository.BuchhalterAPIClient
-	recipeParser        *parser.RecipeParser
 	logger              *slog.Logger
 
 	// Browser

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -128,8 +128,8 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 	logger.Info("Credential items loaded from vault", "num_items", len(vaultItems), "provider", "1Password", "cli_command", vaultConfigBinary, "vault", vaultConfigBase, "tag", vaultConfigTag)
 
-	// Run recipes
-	go runRecipes(p, logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum, vaultProvider, documentArchive, recipeParser, buchhalterAPIClient)
+	// Run the primary logic
+	go runSyncCommandLogic(p, logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum, vaultProvider, documentArchive, recipeParser, buchhalterAPIClient)
 
 	if _, err := p.Run(); err != nil {
 		logger.Error("Error running program", "error", err)
@@ -138,7 +138,7 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 }
 
-func runRecipes(p *tea.Program, logger *slog.Logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum string, vaultProvider *vault.Provider1Password, documentArchive *archive.DocumentArchive, recipeParser *parser.RecipeParser, buchhalterAPIClient *repository.BuchhalterAPIClient) {
+func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum string, vaultProvider *vault.Provider1Password, documentArchive *archive.DocumentArchive, recipeParser *parser.RecipeParser, buchhalterAPIClient *repository.BuchhalterAPIClient) {
 	p.Send(utils.ViewStatusUpdateMsg{Message: "Building archive index"})
 	logger.Info("Building document archive index ...")
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -106,8 +106,8 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 
 	// Init the bubbletea program
-	viewModel := initialModel(logger, buchhalterAPIClient)
-	p := tea.NewProgram(viewModel)
+	viewModelSync := initviewModelSync(logger, buchhalterAPIClient)
+	p := tea.NewProgram(viewModelSync)
 
 	// Run the primary logic
 	go runSyncCommandLogic(p, logger, config, supplier, buchhalterAPIClient)
@@ -641,8 +641,8 @@ var (
 	appStyle      = lipgloss.NewStyle().Margin(1, 2, 0, 2)
 )
 
-// viewModel is the bubbletea application main viewModel (view)
-type viewModel struct {
+// viewModelSync is the bubbletea application main view model
+type viewModelSync struct {
 	mode string
 
 	// UI
@@ -718,15 +718,15 @@ type viewMsgModeUpdate struct {
 
 type tickMsg time.Time
 
-// initialModel returns the model for the bubbletea application.
-func initialModel(logger *slog.Logger, buchhalterAPIClient *repository.BuchhalterAPIClient) viewModel {
+// initviewModelSync returns the model for the bubbletea application.
+func initviewModelSync(logger *slog.Logger, buchhalterAPIClient *repository.BuchhalterAPIClient) viewModelSync {
 	const numLastResults = 5
 
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = spinnerStyle
 
-	m := viewModel{
+	m := viewModelSync{
 		actionsCompleted: []utils.UIAction{},
 
 		mode:         "sync",
@@ -752,13 +752,13 @@ func initialModel(logger *slog.Logger, buchhalterAPIClient *repository.Buchhalte
 
 // Init initializes the bubbletea application.
 // Returns an initial command for the application to run.
-func (m viewModel) Init() tea.Cmd {
+func (m viewModelSync) Init() tea.Cmd {
 	return m.spinner.Tick
 }
 
 // Update updates the bubbletea application model.
 // Handles incoming events and updates the model accordingly.
-func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m viewModelSync) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
 	case tea.KeyMsg:
@@ -930,7 +930,7 @@ func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the bubbletea application view.
 // Renders the UI based on the data in the model.
-func (m viewModel) View() string {
+func (m viewModelSync) View() string {
 	s := strings.Builder{}
 	s.WriteString(fmt.Sprintf(
 		"%s\n%s\n%s%s\n%s\n",
@@ -1016,7 +1016,7 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-func quit(m viewModel) viewModel {
+func quit(m viewModelSync) viewModelSync {
 	m.quitting = true
 	m.showProgress = false
 

--- a/cmd/vault-select.go
+++ b/cmd/vault-select.go
@@ -82,7 +82,7 @@ type ViewModelVaultSelect struct {
 }
 
 type vaultSelectErrorMsg struct {
-	err string
+	err error
 }
 
 type vaultSelectInitSuccessMsg struct {
@@ -179,7 +179,7 @@ func (m ViewModelVaultSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case vaultSelectErrorMsg:
-		m.actionError = msg.err
+		m.actionError = fmt.Sprintf("%s", msg.err)
 		return m, tea.Quit
 
 	case vaultSelectInitSuccessMsg:

--- a/lib/repository/repository.go
+++ b/lib/repository/repository.go
@@ -236,6 +236,15 @@ func (c *BuchhalterAPIClient) SendMetrics(runData RunData, cliVersion, chromeVer
 	if err != nil {
 		return err
 	}
+
+	c.logger.Info("Sending metrics to Buchhalter SaaS",
+		"url", apiUrl,
+		"cliVersion", md.CliVersion,
+		"oicdbVersion", md.OicdbVersion,
+		"vaultVersion", md.VaultVersion,
+		"chromeVersion", md.ChromeVersion,
+		"os", md.OS,
+	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiUrl, bytes.NewBuffer(mdj))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -57,6 +57,7 @@ type UIActionStyle string
 const (
 	UIActionStyleSuccess UIActionStyle = "success"
 	UIActionStyleError   UIActionStyle = "error"
+	UIActionStyleThanks  UIActionStyle = "thanks"
 )
 
 type UIAction struct {


### PR DESCRIPTION
Just a code internal change.
The function `GetHumanReadableErrorMessage` (from the `vault` package) now returns a proper error.

## Merge order

This PR depends on https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/110.
https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/110 need to be merged before this one.