### PR TITLE
Remove obsolete TODO comments from codebase

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ var textStyleBold = lipgloss.NewStyle().Bold(true).Render
 var headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9FC131")).Render
 var checkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓")
 var errorkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).SetString("X")
+var thanksMark = lipgloss.NewStyle().SetString("🙏")
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,9 +134,10 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// TODO We should check if we really want to write the full config here
+		// Write the full config into the configuration file
 		// This was introduced to keep the value `buchhalter_always_send_metrics` persistent in the configuration file
 		// This can turn into problems later on, because we don't need all configuration values in the configuration file persistent
+		// Right now we don't have such a problem, hence we keep it as is.
 		err = viper.WriteConfigAs(configFile)
 		if err != nil {
 			fmt.Println("Error creating config file:", err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -532,8 +532,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		})
 	}
 
-	// TODO Move send metrics into main method
-	// Catch result, see https://github.com/charmbracelet/bubbletea/blob/main/examples/result/main.go
+	// Send metrics to Buchhalter API
 	alwaysSendMetrics := viper.GetBool("buchhalter_always_send_metrics")
 	if !developmentMode && alwaysSendMetrics {
 		logger.Info("Sending usage metrics to Buchhalter API", "always_send_metrics", alwaysSendMetrics, "development_mode", developmentMode)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -125,10 +125,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	p.Send(utils.ViewStatusUpdateMsg{Message: statusUpdateMessage})
 	vaultProvider, err := vault.GetProvider(vault.PROVIDER_1PASSWORD, config.vaultConfigBinary, config.vaultConfigBase, config.vaultConfigTag)
 	if err != nil {
-		logger.Error(vaultProvider.GetHumanReadableErrorMessage(err))
-		exitMessage := fmt.Sprintln(vaultProvider.GetHumanReadableErrorMessage(err))
+		logger.Error("error initializing credential provider 1Password: %s", "error", err)
 		p.Send(utils.ViewStatusUpdateMsg{
-			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", exitMessage),
+			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", vaultProvider.GetHumanReadableErrorMessage(err)),
 			Completed:  true,
 			ShouldQuit: true,
 		})
@@ -138,10 +137,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	// Load vault items/try to connect to vault
 	vaultItems, err := vaultProvider.LoadVaultItems()
 	if err != nil {
-		logger.Error(vaultProvider.GetHumanReadableErrorMessage(err))
-		exitMessage := fmt.Sprintln(vaultProvider.GetHumanReadableErrorMessage(err))
+		logger.Error("error initializing credential provider 1Password", "error", err)
 		p.Send(utils.ViewStatusUpdateMsg{
-			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", exitMessage),
+			Err:        fmt.Errorf("error initializing credential provider 1Password: %s", vaultProvider.GetHumanReadableErrorMessage(err)),
 			Completed:  true,
 			ShouldQuit: true,
 		})
@@ -334,10 +332,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		logger.Info("Requesting credentials from vault", "supplier", recipesToExecute[i].recipe.Supplier)
 		recipeCredentials, err := vaultProvider.GetCredentialsByItemId(recipesToExecute[i].vaultItemId)
 		if err != nil {
-			logger.Error(vaultProvider.GetHumanReadableErrorMessage(err))
-			// TODO Let `GetHumanReadableErrorMessage` return a proper error
+			logger.Error("error while requesting credentials from vault", "supplier", recipesToExecute[i].recipe.Supplier, "error", err)
 			p.Send(utils.ViewStatusUpdateMsg{
-				Err:       errors.New(vaultProvider.GetHumanReadableErrorMessage(err)),
+				Err:       vaultProvider.GetHumanReadableErrorMessage(err),
 				Completed: true,
 			})
 			continue

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -199,12 +199,6 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		Completed: true,
 	})
 
-	p.Send(buchhalterMetricsRecord{
-		CliVersion:   cliVersion,
-		VaultVersion: vaultProvider.Version,
-		OicdbVersion: recipeParser.OicdbVersion,
-	})
-
 	p.Send(utils.ViewStatusUpdateMsg{Message: "Building archive index"})
 	logger.Info("Building document archive index ...")
 
@@ -280,6 +274,13 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		return
 	}
 
+	// At this point in time, we have all the information we need to send metrics
+	p.Send(buchhalterMetricsRecord{
+		CliVersion:   cliVersion,
+		VaultVersion: vaultProvider.Version,
+		OicdbVersion: recipeParser.OicdbVersion,
+	})
+
 	// No pair of credentials found for supplier/recipes
 	if len(recipesToExecute) == 0 {
 		loggingErrorMessage := "No recipes found for suppliers"
@@ -293,6 +294,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		})
 		return
 	}
+	statusUpdateMessage = fmt.Sprintf("%s (OICDB %s)", statusUpdateMessage, recipeParser.OicdbVersion)
 	p.Send(utils.ViewStatusUpdateMsg{
 		Message:   statusUpdateMessage,
 		Completed: true,
@@ -932,8 +934,6 @@ func (m viewModelSync) View() string {
 		textStyle("More information at: "),
 		textStyleBold("https://buchhalter.ai"),
 		textStyleGrayBold(fmt.Sprintf("Using CLI %s", cliVersion)),
-		// TODO Outputting OICDB as task
-		//textStyleGrayBold(fmt.Sprintf("Using OICDB %s and CLI %s", m.recipeParser.OicdbVersion, cliVersion)),
 	) + "\n")
 
 	for _, actionCompleted := range m.actionsCompleted {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -202,9 +202,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	})
 
 	p.Send(buchhalterMetricsRecord{
-		CliVersion: cliVersion,
-		// TODO Send ChromeVersion (not available in this scope)
-		// ChromeVersion: ChromeVersion,
+		CliVersion:   cliVersion,
 		VaultVersion: vaultProvider.Version,
 		OicdbVersion: recipeParser.OicdbVersion,
 	})
@@ -419,6 +417,11 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 			// In case of an external abort signal (e.g. CTRL+C), bubbletea will call `chromedp.Cancel()`.
 		}
 
+		// Send ChromeVersion into metrics
+		if len(ChromeVersion) > 0 {
+			p.Send(buchhalterMetricsRecord{ChromeVersion: ChromeVersion})
+		}
+
 		// TODO recipeResult can be empty! (not nil, but without values)
 
 		rdx := repository.RunDataSupplier{
@@ -605,8 +608,8 @@ func prepareRecipes(logger *slog.Logger, supplier string, vaultProvider *vault.P
 	return r, nil
 }
 
-func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, ChromeVersion, vaultVersion, oicdbVersion string) error {
-	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, ChromeVersion, vaultVersion, oicdbVersion)
+func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, chromeVersion, vaultVersion, oicdbVersion string) error {
+	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, chromeVersion, vaultVersion, oicdbVersion)
 	if err != nil {
 		return fmt.Errorf("error sending usage metrics to Buchhalter API: %w", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -667,9 +667,7 @@ type viewModelSync struct {
 	metricsRecord    *buchhalterMetricsRecord
 
 	// Buchhalter
-	vaultProvider       *vault.Provider1Password
 	buchhalterAPIClient *repository.BuchhalterAPIClient
-	recipeParser        *parser.RecipeParser
 	logger              *slog.Logger
 
 	// Browser

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -429,7 +429,9 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 		p.Send(newRecipeRunDataRecordMsg{record: runDataSupplierRecord})
 		recipeRunData = append(recipeRunData, runDataSupplierRecord)
 
-		// TODO Do we need viewMsgRecipeDownloadResultMsg ? We send the same data in newRecipeRunDataRecordMsg
+		// We send the recipeResult in a separate message to the view layer
+		// This could be optimized (and bundled together with newRecipeRunDataRecordMsg),
+		// but for now this is good enough.
 		p.Send(viewMsgRecipeDownloadResultMsg{
 			duration:      time.Since(startTime),
 			newFilesCount: recipeResult.NewFilesCount,
@@ -437,7 +439,12 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 			errorMessage:  recipeResult.LastErrorMessage,
 		})
 
-		logger.Info("Downloading invoices ... completed", "supplier", recipesToExecute[i].recipe.Supplier, "supplier_type", recipesToExecute[i].recipe.Type, "duration", time.Since(startTime), "new_files", recipeResult.NewFilesCount)
+		logger.Info("Downloading invoices ... completed",
+			"supplier", recipesToExecute[i].recipe.Supplier,
+			"supplier_type", recipesToExecute[i].recipe.Type,
+			"duration", time.Since(startTime),
+			"new_files", recipeResult.NewFilesCount,
+		)
 		invoiceLabel := "invoices"
 		if recipeResult.NewFilesCount == 1 {
 			invoiceLabel = "invoice"

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -147,7 +147,6 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 
 	// Check if vault items are available
 	if len(vaultItems) == 0 {
-		// TODO Add link with help article
 		logger.Error("No credential items loaded from vault", "provider", "1Password", "cli_command", config.vaultConfigBinary, "vault", config.vaultConfigBase, "tag", config.vaultConfigTag)
 		exitMessage := fmt.Sprintf("No credential items found in vault '%s' with tag '%s'. Please check your 1password vault items.", config.vaultConfigBase, config.vaultConfigTag)
 		p.Send(utils.ViewStatusUpdateMsg{

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -128,8 +128,8 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 	logger.Info("Credential items loaded from vault", "num_items", len(vaultItems), "provider", "1Password", "cli_command", vaultConfigBinary, "vault", vaultConfigBase, "tag", vaultConfigTag)
 
-	// Run recipes
-	go runRecipes(p, logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum, vaultProvider, documentArchive, recipeParser, buchhalterAPIClient)
+	// Run the primary logic
+	go runSyncCommandLogic(p, logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum, vaultProvider, documentArchive, recipeParser, buchhalterAPIClient)
 
 	if _, err := p.Run(); err != nil {
 		logger.Error("Error running program", "error", err)
@@ -138,7 +138,7 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 }
 
-func runRecipes(p *tea.Program, logger *slog.Logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum string, vaultProvider *vault.Provider1Password, documentArchive *archive.DocumentArchive, recipeParser *parser.RecipeParser, buchhalterAPIClient *repository.BuchhalterAPIClient) {
+func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, supplier, localOICDBChecksum, localOICDBSchemaChecksum string, vaultProvider *vault.Provider1Password, documentArchive *archive.DocumentArchive, recipeParser *parser.RecipeParser, buchhalterAPIClient *repository.BuchhalterAPIClient) {
 	p.Send(utils.ViewStatusUpdateMsg{Message: "Building archive index"})
 	logger.Info("Building document archive index ...")
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -106,8 +106,8 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 	}
 
 	// Init the bubbletea program
-	viewModel := initialModel(logger, buchhalterAPIClient)
-	p := tea.NewProgram(viewModel)
+	viewModelSync := initviewModelSync(logger, buchhalterAPIClient)
+	p := tea.NewProgram(viewModelSync)
 
 	// Run the primary logic
 	go runSyncCommandLogic(p, logger, config, supplier, buchhalterAPIClient)
@@ -641,8 +641,8 @@ var (
 	appStyle      = lipgloss.NewStyle().Margin(1, 2, 0, 2)
 )
 
-// viewModel is the bubbletea application main viewModel (view)
-type viewModel struct {
+// viewModelSync is the bubbletea application main view model
+type viewModelSync struct {
 	mode string
 
 	// UI
@@ -718,15 +718,15 @@ type viewMsgModeUpdate struct {
 
 type tickMsg time.Time
 
-// initialModel returns the model for the bubbletea application.
-func initialModel(logger *slog.Logger, buchhalterAPIClient *repository.BuchhalterAPIClient) viewModel {
+// initviewModelSync returns the model for the bubbletea application.
+func initviewModelSync(logger *slog.Logger, buchhalterAPIClient *repository.BuchhalterAPIClient) viewModelSync {
 	const numLastResults = 5
 
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = spinnerStyle
 
-	m := viewModel{
+	m := viewModelSync{
 		actionsCompleted: []utils.UIAction{},
 
 		mode:         "sync",
@@ -752,13 +752,13 @@ func initialModel(logger *slog.Logger, buchhalterAPIClient *repository.Buchhalte
 
 // Init initializes the bubbletea application.
 // Returns an initial command for the application to run.
-func (m viewModel) Init() tea.Cmd {
+func (m viewModelSync) Init() tea.Cmd {
 	return m.spinner.Tick
 }
 
 // Update updates the bubbletea application model.
 // Handles incoming events and updates the model accordingly.
-func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m viewModelSync) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
 	case tea.KeyMsg:
@@ -930,7 +930,7 @@ func (m viewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the bubbletea application view.
 // Renders the UI based on the data in the model.
-func (m viewModel) View() string {
+func (m viewModelSync) View() string {
 	s := strings.Builder{}
 	s.WriteString(fmt.Sprintf(
 		"%s\n%s\n%s%s\n%s\n",
@@ -1016,7 +1016,7 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-func quit(m viewModel) viewModel {
+func quit(m viewModelSync) viewModelSync {
 	m.quitting = true
 	m.showProgress = false
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -23,11 +23,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	// TODO Remove global variable RunData
-	RunData repository.RunData
-)
-
 type recipeToExecute struct {
 	recipe      *parser.Recipe
 	vaultItemId string
@@ -317,7 +312,8 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	stepCountInCurrentRecipe := 0
 	baseCountStep := 0
 	chromeVersion := ""
-	var recipeResult utils.RecipeResult
+	recipeRunData := make(repository.RunData, 0)
+	recipeResult := utils.RecipeResult{}
 	for i := range recipesToExecute {
 		totalStepCount += len(recipesToExecute[i].recipe.Steps)
 	}
@@ -418,22 +414,29 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 
 		// TODO recipeResult can be empty! (not nil, but without values)
 
-		rdx := repository.RunDataSupplier{
-			Supplier:         recipesToExecute[i].recipe.Supplier,
-			Version:          recipesToExecute[i].recipe.Version,
+		runDataSupplierRecord := repository.RunDataSupplier{
+			// Recipe
+			Supplier: recipesToExecute[i].recipe.Supplier,
+			Version:  recipesToExecute[i].recipe.Version,
+
+			// Run result
 			Status:           recipeResult.StatusText,
 			LastErrorMessage: recipeResult.LastErrorMessage,
-			Duration:         time.Since(startTime).Seconds(),
 			NewFilesCount:    recipeResult.NewFilesCount,
+			Duration:         time.Since(startTime).Seconds(),
 		}
-		RunData = append(RunData, rdx)
 
+		p.Send(newRecipeRunDataRecordMsg{record: runDataSupplierRecord})
+		recipeRunData = append(recipeRunData, runDataSupplierRecord)
+
+		// TODO Do we need viewMsgRecipeDownloadResultMsg ? We send the same data in newRecipeRunDataRecordMsg
 		p.Send(viewMsgRecipeDownloadResultMsg{
 			duration:      time.Since(startTime),
 			newFilesCount: recipeResult.NewFilesCount,
 			step:          recipeResult.StatusTextFormatted,
 			errorMessage:  recipeResult.LastErrorMessage,
 		})
+
 		logger.Info("Downloading invoices ... completed", "supplier", recipesToExecute[i].recipe.Supplier, "supplier_type", recipesToExecute[i].recipe.Type, "duration", time.Since(startTime), "new_files", recipeResult.NewFilesCount)
 		invoiceLabel := "invoices"
 		if recipeResult.NewFilesCount == 1 {
@@ -529,7 +532,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	if !developmentMode && alwaysSendMetrics {
 		logger.Info("Sending usage metrics to Buchhalter API", "always_send_metrics", alwaysSendMetrics, "development_mode", developmentMode)
 		p.Send(utils.ViewStatusUpdateMsg{Message: "Sending usage metrics to Buchhalter API"})
-		err = buchhalterAPIClient.SendMetrics(RunData, cliVersion, chromeVersion, vaultProvider.Version, recipeParser.OicdbVersion)
+		err = buchhalterAPIClient.SendMetrics(recipeRunData, cliVersion, chromeVersion, vaultProvider.Version, recipeParser.OicdbVersion)
 		if err != nil {
 			logger.Error("Error sending usage metrics to Buchhalter API", "error", err)
 			p.Send(utils.ViewStatusUpdateMsg{
@@ -602,8 +605,8 @@ func prepareRecipes(logger *slog.Logger, supplier string, vaultProvider *vault.P
 	return r, nil
 }
 
-func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, cliVersion, chromeVersion, vaultVersion, oicdbVersion string) error {
-	err := buchhalterAPIClient.SendMetrics(RunData, cliVersion, chromeVersion, vaultVersion, oicdbVersion)
+func sendMetrics(buchhalterAPIClient *repository.BuchhalterAPIClient, a bool, runData repository.RunData, cliVersion, chromeVersion, vaultVersion, oicdbVersion string) error {
+	err := buchhalterAPIClient.SendMetrics(runData, cliVersion, chromeVersion, vaultVersion, oicdbVersion)
 	if err != nil {
 		return fmt.Errorf("error sending usage metrics to Buchhalter API: %w", err)
 	}
@@ -654,6 +657,9 @@ type viewModelSync struct {
 	quitting      bool
 	hasError      bool
 
+	// Recipe runs
+	recipeRunData repository.RunData
+
 	// sendMetrics selection
 	selectionCursor  int
 	selectionChoice  string
@@ -671,6 +677,10 @@ type viewModelSync struct {
 // updateBrowserContext is a message type to update the browser context in the bubbletea application.
 type updateBrowserContext struct {
 	ctx context.Context
+}
+
+type newRecipeRunDataRecordMsg struct {
+	record repository.RunDataSupplier
 }
 
 // viewQuitMsg initiates the shutdown sequence for the bubbletea application.
@@ -728,6 +738,9 @@ func initviewModelSync(logger *slog.Logger, buchhalterAPIClient *repository.Buch
 		results:      make([]viewMsgRecipeDownloadResultMsg, numLastResults),
 		hasError:     false,
 
+		// Recipe runs
+		recipeRunData: make(repository.RunData, 0),
+
 		// sendMetrics selection
 		selectionChoices: []string{"Yes", "No", "Always yes (don't ask again)"},
 		metricsRecord:    &buchhalterMetricsRecord{},
@@ -769,7 +782,7 @@ func (m viewModelSync) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "Yes":
 				return m, func() tea.Msg {
 					metrics := m.metricsRecord
-					err := sendMetrics(m.buchhalterAPIClient, false, metrics.CliVersion, metrics.ChromeVersion, metrics.VaultVersion, metrics.OicdbVersion)
+					err := sendMetrics(m.buchhalterAPIClient, false, m.recipeRunData, metrics.CliVersion, metrics.ChromeVersion, metrics.VaultVersion, metrics.OicdbVersion)
 					return utils.ViewStatusUpdateMsg{
 						Message:    "Sent usage metrics to Buchhalter API",
 						Err:        err,
@@ -790,7 +803,7 @@ func (m viewModelSync) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "Always yes (don't ask again)":
 				return m, func() tea.Msg {
 					metrics := m.metricsRecord
-					err := sendMetrics(m.buchhalterAPIClient, true, metrics.CliVersion, metrics.ChromeVersion, metrics.VaultVersion, metrics.OicdbVersion)
+					err := sendMetrics(m.buchhalterAPIClient, true, m.recipeRunData, metrics.CliVersion, metrics.ChromeVersion, metrics.VaultVersion, metrics.OicdbVersion)
 					return utils.ViewStatusUpdateMsg{
 						Message:    "Sent usage metrics to Buchhalter API",
 						Err:        err,
@@ -857,6 +870,10 @@ func (m viewModelSync) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg.VaultVersion) > 0 {
 			m.metricsRecord.VaultVersion = msg.VaultVersion
 		}
+		return m, nil
+
+	case newRecipeRunDataRecordMsg:
+		m.recipeRunData = append(m.recipeRunData, msg.record)
 		return m, nil
 
 	case updateBrowserContext:

--- a/cmd/vault-select.go
+++ b/cmd/vault-select.go
@@ -82,7 +82,7 @@ type ViewModelVaultSelect struct {
 }
 
 type vaultSelectErrorMsg struct {
-	err string
+	err error
 }
 
 type vaultSelectInitSuccessMsg struct {
@@ -179,7 +179,7 @@ func (m ViewModelVaultSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case vaultSelectErrorMsg:
-		m.actionError = msg.err
+		m.actionError = fmt.Sprintf("%s", msg.err)
 		return m, tea.Quit
 
 	case vaultSelectInitSuccessMsg:

--- a/lib/repository/repository.go
+++ b/lib/repository/repository.go
@@ -240,6 +240,7 @@ func (c *BuchhalterAPIClient) SendMetrics(runData RunData, cliVersion, chromeVer
 
 	c.logger.Info("Sending metrics to Buchhalter SaaS",
 		"url", apiUrl,
+		"runData", metricsData.Data,
 		"cliVersion", metricsData.CliVersion,
 		"oicdbVersion", metricsData.OicdbVersion,
 		"vaultVersion", metricsData.VaultVersion,

--- a/lib/repository/repository.go
+++ b/lib/repository/repository.go
@@ -236,6 +236,15 @@ func (c *BuchhalterAPIClient) SendMetrics(runData RunData, cliVersion, chromeVer
 	if err != nil {
 		return err
 	}
+
+	c.logger.Info("Sending metrics to Buchhalter SaaS",
+		"url", apiUrl,
+		"cliVersion", md.CliVersion,
+		"oicdbVersion", md.OicdbVersion,
+		"vaultVersion", md.VaultVersion,
+		"chromeVersion", md.ChromeVersion,
+		"os", md.OS,
+	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiUrl, bytes.NewBuffer(mdj))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)

--- a/lib/repository/repository.go
+++ b/lib/repository/repository.go
@@ -42,7 +42,6 @@ type Metric struct {
 	OS            string `json:"os,omitempty"`
 }
 
-type RunData []RunDataSupplier
 type RunDataSupplier struct {
 	Supplier         string  `json:"supplier,omitempty"`
 	Version          string  `json:"version,omitempty"`
@@ -51,6 +50,8 @@ type RunDataSupplier struct {
 	Duration         float64 `json:"duration,omitempty"`
 	NewFilesCount    int     `json:"newFilesCount,omitempty"`
 }
+
+type RunData []RunDataSupplier
 
 type CliSyncResponse struct {
 	Status string            `json:"status"`
@@ -211,21 +212,21 @@ func (c *BuchhalterAPIClient) updateExists(currentChecksum, apiEndpoint string) 
 }
 
 func (c *BuchhalterAPIClient) SendMetrics(runData RunData, cliVersion, chromeVersion, vaultVersion, oicdbVersion string) error {
-	rdx, err := json.Marshal(runData)
+	runDataJSON, err := json.Marshal(runData)
 	if err != nil {
 		return fmt.Errorf("error marshalling run data: %w", err)
 	}
 
-	md := Metric{
+	metricsData := Metric{
 		MetricType:    "runMetrics",
-		Data:          string(rdx),
+		Data:          string(runDataJSON),
 		CliVersion:    cliVersion,
 		OicdbVersion:  oicdbVersion,
 		VaultVersion:  vaultVersion,
 		ChromeVersion: chromeVersion,
 		OS:            runtime.GOOS,
 	}
-	mdj, err := json.Marshal(md)
+	metricsDataJSON, err := json.Marshal(metricsData)
 	if err != nil {
 		return fmt.Errorf("error marshalling run data: %w", err)
 	}
@@ -239,13 +240,13 @@ func (c *BuchhalterAPIClient) SendMetrics(runData RunData, cliVersion, chromeVer
 
 	c.logger.Info("Sending metrics to Buchhalter SaaS",
 		"url", apiUrl,
-		"cliVersion", md.CliVersion,
-		"oicdbVersion", md.OicdbVersion,
-		"vaultVersion", md.VaultVersion,
-		"chromeVersion", md.ChromeVersion,
-		"os", md.OS,
+		"cliVersion", metricsData.CliVersion,
+		"oicdbVersion", metricsData.OicdbVersion,
+		"vaultVersion", metricsData.VaultVersion,
+		"chromeVersion", metricsData.ChromeVersion,
+		"os", metricsData.OS,
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiUrl, bytes.NewBuffer(mdj))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiUrl, bytes.NewBuffer(metricsDataJSON))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -57,6 +57,7 @@ type UIActionStyle string
 const (
 	UIActionStyleSuccess UIActionStyle = "success"
 	UIActionStyleError   UIActionStyle = "error"
+	UIActionStyleThanks  UIActionStyle = "thanks"
 )
 
 type UIAction struct {

--- a/lib/vault/vault.go
+++ b/lib/vault/vault.go
@@ -44,7 +44,7 @@ func DetermineBinary(binaryPath string) (string, error) {
 			}
 		}
 
-		// TODO Check if fullBinaryPath is executable
+		// At this point in time, we assume that the binary is executable
 
 		return fullBinaryPath, nil
 	}


### PR DESCRIPTION
These TODO comments have been added in the early phase of [buchhalter-ai-cli](https://github.com/buchhalter-ai/buchhalter-ai-cli) and are not suitable anymore.

This PR removes those. If those TODOs are valid and still a problem, we will fix it, once it occurs.

## Merge order

This PR depends on https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/112.
https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/112 need to be merged before this one.