### PR TITLE
Documents directory: Add Vault ID to path to split different vaults

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,14 +172,9 @@ func initConfig() {
 		os.Exit(1)
 	}
 	viper.Set("buchhalter_api_token", apiConfig.APIKey)
-	teamSlug := "default"
-	if len(apiConfig.TeamSlug) > 0 {
-		teamSlug = apiConfig.TeamSlug
-	}
-	viper.Set("buchhalter_api_team_slug", teamSlug)
 
-	// Documents directory
-	buchhalterDocumentsDirectory := filepath.Join(buchhalterDir, "documents", teamSlug)
+	// Basic Documents directory
+	buchhalterDocumentsDirectory := filepath.Join(buchhalterDir, "documents")
 	viper.Set("buchhalter_documents_directory", buchhalterDocumentsDirectory)
 
 	// Create main directory if not exists

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -129,7 +129,7 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 
 	// Create documents directory if not exists
 	if err := utils.CreateDirectoryIfNotExists(buchhalterDocumentsDirectory); err != nil {
-		exitMessage := fmt.Sprintf("Error creating main document directory: %w", err)
+		exitMessage := fmt.Sprintf("Error creating main document directory: %s", err)
 		exitWithLogo(exitMessage)
 	}
 


### PR DESCRIPTION
## What are we doing here?

With `buchhalter vault add/select` we can now manage multiple vaults.
This means that when documents are downloaded, those need to be split in the download directory as well.
This PR adds the vault id into the document download directory path like `~/buchhalter/documents/hphg3rhp5icqha5llobppcm34va`.

If we don't have a vault, for whatever reason, the path is `~/buchhalter/documents/default`.

## How to test?

1. Add two or more vaults via `buchhalter vault add/select`
2. Run a sync command for each vault (selecting the vault either via `buchhalter vault select` or via cmd argument
3. Analyze your `~/buchhalter/documents/` and subdirectories