### PR TITLE
SaaS API Key: Use key that is configured with the respective vault

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,14 +172,9 @@ func initConfig() {
 		os.Exit(1)
 	}
 	viper.Set("buchhalter_api_token", apiConfig.APIKey)
-	teamSlug := "default"
-	if len(apiConfig.TeamSlug) > 0 {
-		teamSlug = apiConfig.TeamSlug
-	}
-	viper.Set("buchhalter_api_team_slug", teamSlug)
 
-	// Documents directory
-	buchhalterDocumentsDirectory := filepath.Join(buchhalterDir, "documents", teamSlug)
+	// Basic Documents directory
+	buchhalterDocumentsDirectory := filepath.Join(buchhalterDir, "documents")
 	viper.Set("buchhalter_documents_directory", buchhalterDocumentsDirectory)
 
 	// Create main directory if not exists

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"buchhalter/lib/repository"
 	"buchhalter/lib/utils"
 )
 
@@ -129,11 +128,6 @@ func initConfig() {
 	viper.SetDefault("dev", false)
 
 	// Non documented settings (on purpose)
-	// Those settings are either part of a different configuration file or are not meant to be changed by the user
-	// E.g. when they are calculated based on other settings
-	viper.SetDefault("buchhalter_api_token", "")
-	// See below
-	// - buchhalter_api_team_slug
 	// - buchhalter_documents_directory
 
 	// Check if config file exists or create it
@@ -162,16 +156,6 @@ func initConfig() {
 		fmt.Println("Error reading config file:", err)
 		os.Exit(1)
 	}
-
-	// Read local API settings
-	dummyLogger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	buchhalterConfig := repository.NewBuchhalterConfig(dummyLogger, buchhalterConfigDir)
-	apiConfig, err := buchhalterConfig.GetLocalAPIConfig()
-	if err != nil {
-		fmt.Println("Error reading api token file:", err)
-		os.Exit(1)
-	}
-	viper.Set("buchhalter_api_token", apiConfig.APIKey)
 
 	// Basic Documents directory
 	buchhalterDocumentsDirectory := filepath.Join(buchhalterDir, "documents")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -114,18 +114,19 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 		vaultSelectionMode = VaultSelectionNothingConfigured
 	}
 
-	var documentDirectoryID string
 	if selectedVault == nil {
-		selectedVault = &vaultConfiguration{}
-		documentDirectoryID = "default"
-	} else {
-		documentDirectoryID = selectedVault.ID
+		selectedVault = &vaultConfiguration{
+			ID:               "default",
+			Name:             "buchhalter-default",
+			BuchhalterAPIKey: "",
+			Selected:         true,
+		}
 	}
 
 	// Craft documents directory with Vault ID
 	// By this, we split the documents into different directories based on the vault ID
 	buchhalterDocumentsDirectory := viper.GetString("buchhalter_documents_directory")
-	buchhalterDocumentsDirectory = filepath.Join(buchhalterDocumentsDirectory, documentDirectoryID)
+	buchhalterDocumentsDirectory = filepath.Join(buchhalterDocumentsDirectory, selectedVault.ID)
 
 	// Create documents directory if not exists
 	if err := utils.CreateDirectoryIfNotExists(buchhalterDocumentsDirectory); err != nil {
@@ -163,8 +164,7 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 
 	// Init Buchhalter API client
 	apiHost := viper.GetString("buchhalter_api_host")
-	apiToken := viper.GetString("buchhalter_api_token")
-	buchhalterAPIClient, err := repository.NewBuchhalterAPIClient(logger, apiHost, config.buchhalterConfigDirectory, apiToken, cliVersion)
+	buchhalterAPIClient, err := repository.NewBuchhalterAPIClient(logger, apiHost, config.buchhalterConfigDirectory, selectedVault.BuchhalterAPIKey, cliVersion)
 	if err != nil {
 		logger.Error("Error initializing Buchhalter API client", "error", err)
 		exitMessage := fmt.Sprintf("Error initializing Buchhalter API client: %s", err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -129,7 +129,7 @@ func RunSyncCommand(cmd *cobra.Command, cmdArgs []string) {
 
 	// Create documents directory if not exists
 	if err := utils.CreateDirectoryIfNotExists(buchhalterDocumentsDirectory); err != nil {
-		exitMessage := fmt.Sprintf("Error creating main document directory: %w", err)
+		exitMessage := fmt.Sprintf("Error creating main document directory: %s", err)
 		exitWithLogo(exitMessage)
 	}
 


### PR DESCRIPTION
## Context

With `buchhalter vault add` you can now add a SaaS key in relation to a vault.
This PR is using the respective SaaS Key in the `buchhalter sync` command.

## How to test

1. Have 2 Vaults with two different buchhalter SaaS keys / accounts
2. Run the sync command with account 1
3. Run the sync command with account 2
4. Check the buchhalter SaaS page

## Merge order

This PR depends on https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/133
https://github.com/buchhalter-ai/buchhalter-ai-cli/pull/133 need to be merged before this PR.