### PR TITLE
Feat: Improve 2FA/TOTP Handling and Reliability (Closes #153)

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -238,7 +238,7 @@ func runSyncCommandLogic(p *tea.Program, logger *slog.Logger, config *syncComman
 	logger.Info("Initializing credential provider", "provider", "1Password", "cli_command", config.vaultConfigBinary, "vault", config.vaultConfig.Name, "tag", config.vaultConfigTag)
 	statusUpdateMessage := fmt.Sprintf("Initializing credential provider 1Password with vault '%s' and tag '%s'", config.vaultConfig.Name, config.vaultConfigTag)
 	p.Send(utils.ViewStatusUpdateMsg{Message: statusUpdateMessage})
-	vaultProvider, err := vault.GetProvider(vault.PROVIDER_1PASSWORD, config.vaultConfigBinary, config.vaultConfig.Name, config.vaultConfigTag)
+	vaultProvider, err := vault.GetProvider(vault.PROVIDER_1PASSWORD, config.vaultConfigBinary, config.vaultConfig.Name, config.vaultConfigTag, logger)
 	if err != nil {
 		logger.Error("error initializing credential provider 1Password: %s", "error", err)
 		p.Send(utils.ViewStatusUpdateMsg{

--- a/lib/browser/browser.go
+++ b/lib/browser/browser.go
@@ -578,12 +578,12 @@ func (b *BrowserDriver) parseCredentialPlaceholders(value string, credentials *v
 					// For now, we'll log the error and proceed with an empty TOTP, which will likely cause the step to fail.
 					// This makes the failure explicit at the point of use.
 					value = strings.Replace(value, "{{ totp }}", "", -1) // Replace with empty if fetch fails
-					return value, err // Propagate the error from GetTotpForItem
+					return value, err                                    // Propagate the error from GetTotpForItem
 				} else { // err == nil
 					if totp == "" { // Fetched TOTP is empty
 						errMsg := fmt.Sprintf("fetched TOTP for credential ID %s is empty. Please check the 1Password item", credentials.Id)
 						b.logger.Error(errMsg, "credential_id", credentials.Id) // Log as error
-						return value, fmt.Errorf(errMsg) // Return original value and the error
+						return value, fmt.Errorf(errMsg)                        // Return original value and the error
 					} else { // Fetched TOTP is not empty and fetch was successful
 						// Avoid logging the actual TOTP for security, log its presence or length
 						b.logger.Info("Successfully fetched TOTP on demand", "credential_id", credentials.Id, "totp_present", true)

--- a/lib/browser/browser.go
+++ b/lib/browser/browser.go
@@ -5,6 +5,7 @@ package browser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -583,7 +584,7 @@ func (b *BrowserDriver) parseCredentialPlaceholders(value string, credentials *v
 					if totp == "" { // Fetched TOTP is empty
 						errMsg := fmt.Sprintf("fetched TOTP for credential ID %s is empty. Please check the 1Password item", credentials.Id)
 						b.logger.Error(errMsg, "credential_id", credentials.Id) // Log as error
-						return value, fmt.Errorf(errMsg)                        // Return original value and the error
+						return value, errors.New(errMsg)                        // Return original value and the error
 					} else { // Fetched TOTP is not empty and fetch was successful
 						// Avoid logging the actual TOTP for security, log its presence or length
 						b.logger.Info("Successfully fetched TOTP on demand", "credential_id", credentials.Id, "totp_present", true)

--- a/lib/browser/browser.go
+++ b/lib/browser/browser.go
@@ -327,7 +327,12 @@ func (b *BrowserDriver) stepClick(ctx context.Context, step parser.Step) utils.S
 func (b *BrowserDriver) stepType(ctx context.Context, step parser.Step, credentials *vault.Credentials) utils.StepResult {
 	b.logger.Debug("Executing recipe step", "action", step.Action, "selector", step.Selector, "value", step.Value)
 
-	step.Value = b.parseCredentialPlaceholders(step.Value, credentials)
+	parsedValue, err := b.parseCredentialPlaceholders(step.Value, credentials)
+	if err != nil {
+		b.logger.Error("Failed to parse credential placeholders for stepType", "error", err.Error())
+		return utils.StepResult{Status: "error", Message: fmt.Sprintf("Error processing credentials: %v", err)}
+	}
+	step.Value = parsedValue
 
 	opts := []chromedp.QueryOption{
 		chromedp.NodeReady,
@@ -557,11 +562,48 @@ func (b *BrowserDriver) stepRunScriptDownloadUrls(ctx context.Context, step pars
 	return utils.StepResult{Status: "success"}
 }
 
-func (b *BrowserDriver) parseCredentialPlaceholders(value string, credentials *vault.Credentials) string {
+func (b *BrowserDriver) parseCredentialPlaceholders(value string, credentials *vault.Credentials) (string, error) {
 	value = strings.Replace(value, "{{ username }}", credentials.Username, -1)
 	value = strings.Replace(value, "{{ password }}", credentials.Password, -1)
-	value = strings.Replace(value, "{{ totp }}", credentials.Totp, -1)
-	return value
+
+	if strings.Contains(value, "{{ totp }}") {
+		if credentials != nil && credentials.VaultProvider != nil {
+			// Try to assert the type to *vault.Provider1Password
+			// In the future, this might need to be a more generic interface call
+			if provider, ok := credentials.VaultProvider.(interface{ GetTotpForItem(string) (string, error) }); ok {
+				totp, err := provider.GetTotpForItem(credentials.Id)
+				if err != nil {
+					b.logger.Error("Failed to fetch TOTP on demand", "credential_id", credentials.Id, "error", err.Error())
+					// Decide how to handle error: return original value, or empty string for totp, or propagate error
+					// For now, we'll log the error and proceed with an empty TOTP, which will likely cause the step to fail.
+					// This makes the failure explicit at the point of use.
+					value = strings.Replace(value, "{{ totp }}", "", -1) // Replace with empty if fetch fails
+					return value, err // Propagate the error from GetTotpForItem
+				} else { // err == nil
+					if totp == "" { // Fetched TOTP is empty
+						errMsg := fmt.Sprintf("fetched TOTP for credential ID %s is empty. Please check the 1Password item", credentials.Id)
+						b.logger.Error(errMsg, "credential_id", credentials.Id) // Log as error
+						return value, fmt.Errorf(errMsg) // Return original value and the error
+					} else { // Fetched TOTP is not empty and fetch was successful
+						// Avoid logging the actual TOTP for security, log its presence or length
+						b.logger.Info("Successfully fetched TOTP on demand", "credential_id", credentials.Id, "totp_present", true)
+						value = strings.Replace(value, "{{ totp }}", totp, -1)
+						credentials.Totp = totp // Optionally update the credentials struct's Totp field
+						// Successful path, error is nil, will be returned by the function's main return path
+					}
+				}
+			} else {
+				b.logger.Warn("VaultProvider does not support GetTotpForItem or is not of expected type. {{totp}} placeholder will not be resolved.", "credential_id", credentials.Id)
+				return value, fmt.Errorf("VaultProvider for credential ID %s does not support GetTotpForItem or is not of expected type; {{totp}} placeholder could not be resolved", credentials.Id)
+			}
+		} else {
+			b.logger.Warn("Credentials or VaultProvider is nil, cannot fetch TOTP on demand. {{totp}} placeholder will not be resolved.", "credential_id", credentials.Id)
+			// Return an error because we expected to fetch a TOTP but couldn't due to missing provider/credentials info for it.
+			return value, fmt.Errorf("credentials or VaultProvider is nil for credential ID %s, cannot fetch TOTP on demand; {{totp}} placeholder could not be resolved", credentials.Id)
+		}
+	} // else, no {{ totp }} placeholder found, nothing to do for totp
+
+	return value, nil
 }
 
 func (b *BrowserDriver) disableImages(ctx context.Context) func(event interface{}) {

--- a/lib/vault/1password.go
+++ b/lib/vault/1password.go
@@ -131,9 +131,9 @@ func (p Provider1Password) GetCredentialsByItemId(itemId string) (*Credentials, 
 	}
 
 	credentials := &Credentials{
-		Id:       itemId,
-		Username: getValueByField(item, "username"),
-		Password: getValueByField(item, "password"),
+		Id:            itemId,
+		Username:      getValueByField(item, "username"),
+		Password:      getValueByField(item, "password"),
 		VaultProvider: p, // Store the provider instance
 	}
 

--- a/lib/vault/1password.go
+++ b/lib/vault/1password.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 const (
@@ -24,13 +26,20 @@ type Provider1Password struct {
 
 	// TODO Check if this is needed
 	UrlsByItemId map[string][]string
+
+	logger *slog.Logger
 }
 
-func New1PasswordProvider(binary, base, tag string) (*Provider1Password, error) {
+func New1PasswordProvider(binary, base, tag string, logger *slog.Logger) (*Provider1Password, error) {
+	if logger == nil {
+		// Fallback to a default logger if none is provided, though ideally it should always be passed.
+		logger = slog.Default()
+	}
 	p := &Provider1Password{
 		base:         base,
 		tag:          tag,
 		UrlsByItemId: make(map[string][]string),
+		logger:       logger,
 	}
 
 	binaryPath, err := DetermineBinary(binary)
@@ -85,7 +94,6 @@ func (p *Provider1Password) LoadVaultItems() (Items, error) {
 	}
 
 	// Read in all urls from a vault item and build up urls per item id map
-	// TODO Check if this is really needed
 	for n := 0; n < len(vaultItems); n++ {
 		var urls []string
 		for i := 0; i < len(vaultItems[n].Urls); i++ {
@@ -126,10 +134,52 @@ func (p Provider1Password) GetCredentialsByItemId(itemId string) (*Credentials, 
 		Id:       itemId,
 		Username: getValueByField(item, "username"),
 		Password: getValueByField(item, "password"),
-		Totp:     getValueByField(item, "totp"),
+		VaultProvider: p, // Store the provider instance
 	}
 
 	return credentials, nil
+}
+
+// GetTotpForItem fetches only the TOTP for a given item ID.
+func (p Provider1Password) GetTotpForItem(itemId string) (string, error) {
+	const totpWindowSeconds = 30
+	const minValidityThresholdSeconds = 5
+	const waitBufferSeconds = 1 // Wait 1 second into the new window
+
+	now := time.Now()
+	currentWindowConsumedSeconds := now.Unix() % totpWindowSeconds
+	remainingSecondsInWindow := totpWindowSeconds - currentWindowConsumedSeconds
+
+	if remainingSecondsInWindow < minValidityThresholdSeconds {
+		waitDuration := time.Duration(remainingSecondsInWindow+waitBufferSeconds) * time.Second
+		p.logger.Info("Current TOTP window is about to expire", "remaining_seconds", remainingSecondsInWindow, "wait_duration", waitDuration.String())
+		time.Sleep(waitDuration)
+		p.logger.Info("Waited for new TOTP window, proceeding to fetch code.")
+	}
+
+	cmdArgs := p.buildVaultCommandArguments([]string{"item", "get", itemId}, true, false)
+
+	// #nosec G204
+	itemGetResponse, err := exec.Command(p.binary, cmdArgs...).Output()
+	if err != nil {
+		return "", ProviderNotInstalledError{
+			Code: ProviderNotInstalledErrorCode,
+			Cmd:  fmt.Sprintf("%s %s", p.binary, strings.Join(cmdArgs, " ")),
+			Err:  err,
+		}
+	}
+
+	var item Item
+	err = json.Unmarshal(itemGetResponse, &item)
+	if err != nil {
+		return "", ProviderResponseParsingError{
+			Code: ProviderResponseParsingErrorCode,
+			Cmd:  fmt.Sprintf("%s %s", p.binary, strings.Join(cmdArgs, " ")),
+			Err:  err,
+		}
+	}
+
+	return getValueByField(item, "totp"), nil
 }
 
 func (p Provider1Password) buildVaultCommandArguments(baseCmd []string, limitVault, includeTag bool) []string {

--- a/lib/vault/types.go
+++ b/lib/vault/types.go
@@ -53,10 +53,10 @@ type Item struct {
 }
 
 type Credentials struct {
-	Id       string
-	Username string
+	Id            string
+	Username      string
 	Password      string
-	Totp          string // This will be populated on-demand
+	Totp          string      // This will be populated on-demand
 	VaultProvider interface{} // To store the vault provider instance (e.g., *Provider1Password)
 }
 

--- a/lib/vault/types.go
+++ b/lib/vault/types.go
@@ -55,8 +55,9 @@ type Item struct {
 type Credentials struct {
 	Id       string
 	Username string
-	Password string
-	Totp     string
+	Password      string
+	Totp          string // This will be populated on-demand
+	VaultProvider interface{} // To store the vault provider instance (e.g., *Provider1Password)
 }
 
 const (

--- a/lib/vault/types.go
+++ b/lib/vault/types.go
@@ -57,6 +57,7 @@ type Credentials struct {
 	Username      string
 	Password      string
 	Totp          string      // This will be populated on-demand
+	// TODO Get rid of interface{}
 	VaultProvider interface{} // To store the vault provider instance (e.g., *Provider1Password)
 }
 

--- a/lib/vault/vault.go
+++ b/lib/vault/vault.go
@@ -3,16 +3,17 @@ package vault
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-func GetProvider(provider, binary, base, tag string) (*Provider1Password, error) {
+func GetProvider(provider, binary, base, tag string, logger *slog.Logger) (*Provider1Password, error) {
 	switch provider {
 	case PROVIDER_1PASSWORD:
-		return New1PasswordProvider(binary, base, tag)
+		return New1PasswordProvider(binary, base, tag, logger)
 	}
 
 	return nil, fmt.Errorf("provider %s not supported", provider)


### PR DESCRIPTION
This pull request implements significant improvements to the 2FA/TOTP handling within recipes, addressing issue #153.

Key changes include:
- **On-Demand TOTP Fetching**: TOTP codes are now fetched from 1Password immediately before they are needed in a recipe step, rather than at the beginning of credential loading. This minimizes issues with TOTP code expiration.
- **Proactive TOTP Window Check**: Before fetching a TOTP, the system now checks the remaining lifetime of the current 30-second TOTP window. If less than 5 seconds remain, it waits for the next window to ensure a fresh code with maximum validity is used.
- **Robust Error Handling**:
    - If a fetched TOTP code is empty (even if the fetch itself was successful), an error is logged, and recipe execution is halted.
    - If the underlying `op` command fails to provide a TOTP, or if the vault provider is misconfigured, an error is returned, and execution stops.
- **Logger Propagation**: Ensured the application logger is correctly passed to the vault provider for consistent logging.
- **Code Cleanup**: Removed obsolete comments related to previous TOTP handling.

These changes aim to make recipe execution more reliable for services requiring 2FA.

Requesting review from @andygrunwald.